### PR TITLE
#5 ft(message): add CRUD operation on messages

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,10 +1,15 @@
 import express from 'express';
 import './models/db';
 import authRouter from './routes/auth';
+import messageRoute from './routes/message.route';
 
 const app = express();
 app.use(express.json())
+
+// routes configuration
 app.use('/users', authRouter)
+app.use('/message', messageRoute)
+
 
 app.use('/', (req, res) => {
     res.status(200).json({message: 'Welcome to Simon-tech website!'})

--- a/src/controllers/authentication/login.js
+++ b/src/controllers/authentication/login.js
@@ -14,13 +14,16 @@ const loginController = async(req, res) => {
         if (!validPass) return res.status(400).json({error: 'Invalid Email or Password!'})
 
         const token = generateToken(loginUser);
+        
+        // eslint-disable-next-line
         const { name, email, _id } = loginUser;
-        return res.status(200)
-                  .json({
-                      message: 'Logged in successfully!',
-                      body:{ name, email, _id },
-                      token
-                    })
+        return res
+            .status(200)
+            .json({
+                message: 'Logged in successfully!',
+                body:{ name, email, _id },
+                token
+            })
     } catch(err) {
         return res.status(500).json({error: err.message})
     }

--- a/src/controllers/authentication/signup.js
+++ b/src/controllers/authentication/signup.js
@@ -6,7 +6,7 @@ const signupController = async(req, res) => {
     const { name, email, password } = req.body;
 
     const userEmail = await User.findOne({email});
-    if (userEmail) res.status(400).json({error: 'Email in use'});
+    if (userEmail) return res.status(400).json({error: 'Email in use'});
 
     const hashedPswd = await hashedPass(password);
     const user = new User({
@@ -17,18 +17,19 @@ const signupController = async(req, res) => {
 
     try {
         const newUser = await user.save();
-        const { savedName, savedEmail, _id, registeredAt } = newUser;
+        // eslint-disable-next-line
+        const { name, email, _id, registeredAt } = newUser;
         const token = generateToken(newUser);
 
         return res
             .status(201)
             .json({
                 message: 'Account created successfully!',
-                Body: { savedName, savedEmail, _id, registeredAt },
+                Body: { name, email, _id, registeredAt },
                 token
             })
     } catch(err) {
-        res.status(500).json({error: err.message})
+        return res.status(500).json({error: err.message})
     }
 };
 

--- a/src/controllers/message/index.js
+++ b/src/controllers/message/index.js
@@ -1,0 +1,51 @@
+import mongoose from 'mongoose';
+import Message from '../../models/message';
+
+export default {
+    sendMessage: async (req, res) => {
+        try {
+            const { name, email, message } = req.body;
+            const messageToSend = await Message.findOne({message});
+    
+            if (messageToSend) return res.status(400).json({error: 'Message has been sent before!'});
+
+            const newMessage = new Message({
+                name,
+                email,
+                message
+            });
+            const savedMessage = await newMessage.save();
+
+            return res.status(201).json({message: 'Message Sent!', savedMessage});
+    
+        } catch(err) {
+            return res.status(500).json({error: err.message});
+        }
+    },
+
+    getMessages: async (req, res) => {
+        try {
+            const allMessages = await Message.find().sort({sentAt: -1});
+            if (allMessages.length === 0) return res.status(400).json({error: 'No message yet!'});
+
+            return res.status(200).json({allMessages});
+        } catch(err) {
+            return res.status(500).json({error: err.message})
+        }      
+    },
+
+    deleteMessage: async (req, res) => {
+        try {
+            const { _id } = req.params;
+            if (!mongoose.Types.ObjectId.isValid(_id)) return res.status(400).json({error: 'Invalid ID'});
+
+            const messageToDelete = await Message.findByIdAndDelete(_id);
+            
+            if (!messageToDelete) return res.status(404).json({error: 'No message with the given ID'});
+
+            return res.status(200).json({message: 'Message deleted successfully!', messageToDelete})
+        } catch(err) {
+            return res.status(500).json({error: err.message})
+        }
+    }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -3,4 +3,5 @@ import app from './app';
 
 const PORT = process.env.PORT || 3000;
 
+// eslint-disable-next-line
 app.listen(PORT, () => console.log(`App running on port ${PORT}`));

--- a/src/middlewares/authorization.js
+++ b/src/middlewares/authorization.js
@@ -1,0 +1,25 @@
+import jwt from 'jsonwebtoken';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+export const auth = (req, res, next) => {
+    const token = req.header('auth-token');
+    if (!token) return res.status(401).json({error: 'Access Denied, login to continue!'});
+
+    try {
+        const secretKey = process.env.SECRET_KEY;
+        const decoded = jwt.verify(token, secretKey);
+        req.user = decoded;
+        
+        return next();
+    } catch(err) {
+        return res.status(403).json({error: 'Invalid Token'})
+    }
+}
+export const adminAuth = (req, res, next) => {
+    const { isAdmin } = req.user;
+    if (!isAdmin) return res.status(401).json({error: 'Access Denied, cannot perform the action unless you are an Admin!'});
+
+    return next();
+};

--- a/src/middlewares/messageValidation .js
+++ b/src/middlewares/messageValidation .js
@@ -1,0 +1,32 @@
+import Joi from '@hapi/joi';
+
+const messageValidation = (req, res, next) => {
+    const schema = Joi.object({
+        name: Joi.string()
+            .required()
+            .messages({'string.empty': 'Name is required!'}),
+        email: Joi.string()
+            .email()
+            .lowercase()
+            .required()
+            .messages({
+                'string.empty': 'Email is required!',
+                'string.lowercase': 'Email must be lowercase!',
+                'string.email': 'Email must be valid!'
+            }),
+        message: Joi.string()
+            .max(150)
+            .required()
+            .messages({
+                'string.empty': 'Message is required!',
+                'string.max': 'Message should be less than 100 characters!'
+            })           
+    });
+
+    const { error } = schema.validate(req.body);
+    if (error) return res.status(400).json({error: error.details[0].message});
+
+    return next();
+};
+
+export default messageValidation;

--- a/src/middlewares/userValidation.js
+++ b/src/middlewares/userValidation.js
@@ -3,32 +3,32 @@ import Joi from '@hapi/joi';
 export const signupValidation = (req, res, next) => {
     const schema = Joi.object({
         name: Joi.string()
-                 .max(50)
-                 .required()
-                 .messages({
-                     'string.empty': 'Name is required!'
-                 }),
+            .max(50)
+            .required()
+            .messages({
+                'string.empty': 'Name is required!'
+            }),
         email: Joi.string()
-                  .email()
-                  .lowercase()
-                  .required()
-                  .messages({
-                      'string.empty': 'Email is required!',
-                      'string.lowercase': 'Email must be lowercase!',
-                      'string.email': 'Email must be valid!'
-                  }),
+            .email()
+            .lowercase()
+            .required()
+            .messages({
+                'string.empty': 'Email is required!',
+                'string.lowercase': 'Email must be lowercase!',
+                'string.email': 'Email must be valid!'
+            }),
         password: Joi.string()
-                     .min(6)
-                     .max(50)
-                     .required()
-                     .regex(/^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])[a-zA-Z0-9]{6,}$/)
-                     .messages({
-                         'string.empty': 'Password is required!',
-                         'string.min': 'Password must be at least 6 characters!',
-                         'string.max': 'Password must be less than 50 characters!',
-                         'string.pattern.base': 
-                         'Password must contain at least one digit, lowercase and uppercase characters!'
-                     })
+            .min(6)
+            .max(50)
+            .required()
+            .regex(/^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])[a-zA-Z0-9]{6,}$/)
+            .messages({
+                'string.empty': 'Password is required!',
+                'string.min': 'Password must be at least 6 characters!',
+                'string.max': 'Password must be less than 50 characters!',
+                'string.pattern.base': 
+                'Password must contain at least one digit, lowercase and uppercase characters!'
+            })
     });
 
     const { error } = schema.validate(req.body);
@@ -40,26 +40,26 @@ export const signupValidation = (req, res, next) => {
 export const loginValidation = (req, res, next) => {
     const schema = Joi.object({
         email: Joi.string()
-                  .email()
-                  .lowercase()
-                  .required()
-                  .messages({
-                      'string.empty': 'Email is required!',
-                      'string.lowercase': 'Email must be lowercase!',
-                      'string.email': 'Email must be valid!'
-                  }),
+            .email()
+            .lowercase()
+            .required()
+            .messages({
+                'string.empty': 'Email is required!',
+                'string.lowercase': 'Email must be lowercase!',
+                'string.email': 'Email must be valid!'
+            }),
         password: Joi.string()
-                     .min(6)
-                     .max(50)
-                     .required()
-                     .regex(/^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])[a-zA-Z0-9]{6,}$/)
-                     .messages({
-                         'string.empty': 'Password is required!',
-                         'string.min': 'Password must be at least 6 characters!',
-                         'string.max': 'Password must be less than 50 characters!',
-                         'string.pattern.base': 
-                         'Password must contain at least one digit, lowercase and uppercase characters!'
-                     })
+            .min(6)
+            .max(50)
+            .required()
+            .regex(/^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])[a-zA-Z0-9]{6,}$/)
+            .messages({
+                'string.empty': 'Password is required!',
+                'string.min': 'Password must be at least 6 characters!',
+                'string.max': 'Password must be less than 50 characters!',
+                'string.pattern.base': 
+                'Password must contain at least one digit, lowercase and uppercase characters!'
+            })
     });
 
     const { error } = schema.validate(req.body);

--- a/src/models/db.js
+++ b/src/models/db.js
@@ -8,10 +8,11 @@ const options = {
     useNewUrlParser: true
 }
 const {
-    db:{ username, password, name }
+    db:{ name }
 } = config;
 
-const url = config.db.database_url || `mongodb+srv://${username}:${password}@cluster0.zjvfn.mongodb.net/${name}`;
+const url = config.db.database_url || `mongodb://localhost:27017/${name}`
+
 
 export default mongoose
     .connect(url, options)

--- a/src/models/message.js
+++ b/src/models/message.js
@@ -1,0 +1,24 @@
+import mongoose from 'mongoose';
+
+const messageSchema = new mongoose.Schema({
+    name: {
+        type: String,
+        required: true
+    },
+    email: {
+        type: String,
+        required: true
+    },
+    message: {
+        type: String,
+        required: true
+    },
+    sentAt: {
+        type: Date,
+        default: new Date()
+    }
+});
+
+const Message = mongoose.model('Message', messageSchema);
+
+export default Message;

--- a/src/routes/message.route.js
+++ b/src/routes/message.route.js
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import messageController  from '../controllers/message/index';
+import messageValidation from '../middlewares/messageValidation ';
+import { auth, adminAuth } from '../middlewares/authorization';
+
+const messageRoute = new Router();
+
+messageRoute
+    .post('/', messageValidation, messageController.sendMessage)
+    .get('/', [auth, adminAuth], messageController.getMessages)
+    .delete('/:_id', [auth, adminAuth], messageController.deleteMessage)
+
+
+export default messageRoute;


### PR DESCRIPTION
#### What does this PR do?

- Add CRUD on messages

#### Description of Task to be completed? 

- Design message schema

- Validate schema object

- Save message

- Add delete endpoint

- Add get endpoint

- Protect the routes


#### How should this be manually tested?

- Clone the repo 

- In your home directory  cd this branch `ft-CRUD-on-messages-#5`

- Then run `npm install` to install all dependencies

- Run `npm run dev` to start the server

- Use postman send a `POST` request on `http://localhost:3000/message`

> You should see a returned result with success message and _id, name, email and message sent

- Use postman send a `GET` request on `http://localhost:3000/message` to get all messages in DB

> You should see the list of all messages in the DB

- To test delete endpoint, send a `DELETE` request on `http://localhost:3000/message/_id` to delete a message with specified `_id`

> If `_id` given doesn't exist you should see a failure message saying that t`he ID doesn't exist or is invalid`

#### Any background context you want to provide?

- To be connected to DB you need to check `env-sample` for the credentials settings

- To **read** or **delete** message you need to have an **Admin** account

#### What are the relevant Trello stories?

- [#5](https://trello.com/c/oZHuLPIT/5-crud-on-messages)

#### Screenshots (if appropriate)
<img width="1440" alt="message-screenshot" src="https://user-images.githubusercontent.com/54619678/96325732-80c50b00-102a-11eb-9f23-fcab2c1eda37.png">


#### Questions:

- N/A
