### PR TITLE
#6 ft(article): enable CRUD operation on articles

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -2,6 +2,7 @@ import express from 'express';
 import './models/db';
 import authRouter from './routes/auth';
 import messageRoute from './routes/message.route';
+import articleRoutes from './routes/articles.route';
 
 const app = express();
 app.use(express.json())
@@ -9,6 +10,7 @@ app.use(express.json())
 // routes configuration
 app.use('/users', authRouter)
 app.use('/message', messageRoute)
+app.use('/articles', articleRoutes)
 
 
 app.use('/', (req, res) => {

--- a/src/controllers/articles/index.js
+++ b/src/controllers/articles/index.js
@@ -1,0 +1,105 @@
+import mongoose from 'mongoose';
+import Article from '../../models/article';
+
+
+export default {
+    addArticle: async (req, res) =>{
+        try {
+            const { title, content } = req.body;
+            const { _id, name } = req.user;
+
+            const articleToAdd = await Article.findOne({title});
+            if (articleToAdd) return res.status(400).json({error: 'Article added before!'});
+
+            const newArticle = new Article({
+                title,
+                author: { _id, name},
+                content
+            });
+
+            const savedArticle = await newArticle.save();
+
+            return res.status(201).json({message: 'Article created successfully', savedArticle})
+        } catch(err) {
+            return res.status(500).json({error: err.message})
+        }
+    },
+
+    editArticle: async (req, res) => {
+        try {
+            const { title, content } = req.body;
+            const { _id } = req.params;
+            if (!mongoose.Types.ObjectId.isValid(_id)) return res.status(400).json({error: 'Invalid ID'});
+
+            const articleToEdit = await Article.findById({_id});
+            if (!articleToEdit) res.status(404).json({error: 'No article with given ID'});
+
+            articleToEdit.set({
+                title: title || articleToEdit.title,
+                content: content || articleToEdit.content
+            });
+
+            const editedArticle = await articleToEdit.save();
+
+            return res.status(200).json({message: 'Article updated successfully', editedArticle})
+        } catch(err) {
+            return res.status(500).json({error: err.message})
+        }
+    },
+
+    deleteArticle: async (req, res) => {
+        try {
+            const { _id } = req.params;
+            if (!mongoose.Types.ObjectId.isValid(_id)) return res.status(400).json({error: 'Invalid ID'});
+
+            const articleToDelete = await Article.findByIdAndDelete(_id);
+            if (!articleToDelete) return res.status(404).json({error: 'No article with the given ID!'});
+
+            return res
+                .status(200)
+                .json({message: 'Article deleted successfully', articleToDelete});
+        } catch(err) {
+            return res.status(500).json({error: err.message})
+        }
+    },
+
+    getArticles: async (req, res) => {
+        try {
+            const { _id } = req.user;
+            const savedArticles = await Article.find()
+                .where({'author._id': {$eq: _id}})
+                .sort({postedAt: -1});
+
+            if (savedArticles.length === 0) return res.status(404).json({error: 'No Articles yet in DB!'});
+
+            return res.status(200).json({savedArticles});
+        } catch(err) {
+            return res.status(500).json({error: err.message});
+        }
+    },
+
+    adminGetArticles: async (req, res) => {
+        try {
+            const savedArticles = await Article.find().sort({postedAt: -1});;
+            if (!savedArticles) return res.status(404).json({error: 'No Articles yet in DB!'});
+
+            return res.status(200).json({savedArticles});
+        } catch(err) {
+            return res.status(500).json({error: err.message});
+        }
+    },
+
+    getSingleArticle: async (req, res) => {
+        try {
+            const { _id } = req.params;
+            if (!mongoose.Types.ObjectId.isValid(_id)) return res.status(400).json({error: 'Invalid ID'});
+
+            const signleArticle = await Article.findById(_id);
+            if (!signleArticle) return res.status(404).json({error: 'No Article with such ID!'});
+
+            return res.status(200).json({signleArticle})
+        } catch(err) {
+            return res.status(500).json({error: err.message})
+        }
+    }
+}

--- a/src/controllers/message/index.js
+++ b/src/controllers/message/index.js
@@ -26,7 +26,7 @@ export default {
     getMessages: async (req, res) => {
         try {
             const allMessages = await Message.find().sort({sentAt: -1});
-            if (allMessages.length === 0) return res.status(400).json({error: 'No message yet!'});
+            if (allMessages.length === 0) return res.status(404).json({error: 'No message yet!'});
 
             return res.status(200).json({allMessages});
         } catch(err) {

--- a/src/helpers/jwToken.js
+++ b/src/helpers/jwToken.js
@@ -4,12 +4,12 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 const generateToken = (data) => {
-    const { name, id, isAdmin } = data;
+    const { name, _id, isAdmin } = data;
     const secretKey = process.env.SECRET_KEY;
 
     try {
         const token =  jwt.sign(
-            {name, id, isAdmin}, 
+            {name, _id, isAdmin}, 
             secretKey, 
             {
                 algorithm: 'HS256',

--- a/src/middlewares/articleValidation.js
+++ b/src/middlewares/articleValidation.js
@@ -1,0 +1,44 @@
+import Joi from '@hapi/joi';
+
+export const newArticleValidation = (req, res, next) => {
+    const schema = Joi.object({
+        title: Joi.string()
+            .required()
+            .messages({
+                'string.empty': 'Title is required!'
+            }),
+        content: Joi.string()
+            .required()
+            .min(30)
+            .messages({
+                'string.empty': 'Content is required!',
+                'string.min': 'Content must be at least 30 characters'
+            })
+    });
+
+    const { error } = schema.validate(req.body);
+    if (error) return res.status(400).json({error: error.details[0].message});
+
+    return next();
+};
+
+export const editArticleValidation = (req, res, next) => {
+    const schema = Joi.object({
+        title: Joi.string()
+            .messages({
+                'string.empty': 'Title should not be empty!'
+            }),
+        content: Joi.string()
+            .required()
+            .min(30)
+            .messages({
+                'string.empty': 'Content is required!',
+                'string.min': 'Content must be at least 30 characters'
+            })
+    });
+
+    const { error } = schema.validate(req.body);
+    if (error) return res.status(400).json({error: error.details[0].message});
+
+    return next();
+}

--- a/src/middlewares/authorization.js
+++ b/src/middlewares/authorization.js
@@ -16,7 +16,9 @@ export const auth = (req, res, next) => {
     } catch(err) {
         return res.status(403).json({error: 'Invalid Token'})
     }
-}
+};
+
+
 export const adminAuth = (req, res, next) => {
     const { isAdmin } = req.user;
     if (!isAdmin) return res.status(401).json({error: 'Access Denied, cannot perform the action unless you are an Admin!'});

--- a/src/models/article.js
+++ b/src/models/article.js
@@ -1,0 +1,46 @@
+import mongoose from 'mongoose';
+
+
+const articleSchema = new mongoose.Schema({
+    title: {
+        type: String,
+        unique: true,
+        required: true
+    },
+    author: {
+        name: String,
+        _id: mongoose.Schema.Types.ObjectId
+    },
+    content: {
+        type: String,
+        required: true
+    },
+    comments: {
+        type: Number,
+        default: 0
+    },
+    likes: {
+        type: Number,
+        default: 0
+    },
+    unlikes: {
+        type: Number,
+        default: 0
+    },
+    views: {
+        type: Number,
+        default: 0
+    },
+    shares: {
+        type: Number,
+        default: 0
+    },
+    postedAt: {
+        type: Date,
+        default: new Intl.DateTimeFormat('en-US', { dateStyle: 'medium'}).format(new Date())
+    }
+});
+
+const Article = mongoose.model('Article', articleSchema);
+
+export default Article;

--- a/src/models/message.js
+++ b/src/models/message.js
@@ -11,6 +11,7 @@ const messageSchema = new mongoose.Schema({
     },
     message: {
         type: String,
+        unique: true,
         required: true
     },
     sentAt: {

--- a/src/routes/articles.route.js
+++ b/src/routes/articles.route.js
@@ -1,0 +1,20 @@
+import { Router } from 'express';
+import articleController from '../controllers/articles';
+import { adminAuth, auth } from '../middlewares/authorization';
+import { 
+    newArticleValidation, 
+    editArticleValidation 
+} from '../middlewares/articleValidation';
+
+const articleRoutes = new Router();
+
+articleRoutes
+    .post('/', auth, newArticleValidation, articleController.addArticle)
+    .get('/admin', [auth, adminAuth], articleController.adminGetArticles)
+    .get('/', auth, articleController.getArticles)
+    .put('/:_id', auth, editArticleValidation, articleController.editArticle)
+    .get('/:_id', auth, articleController.getSingleArticle)
+    .delete('/:_id', auth, articleController.deleteArticle)
+
+
+export default articleRoutes;


### PR DESCRIPTION
#### What does this PR do?

- Enable CRUD on articles

#### Description of Task to be completed? 

- Design article schema

- Validate schema object

- Save articles

- Add post endpoint

- Add delete endpoint

- Add get endpoint

- Add edit endpoint

- Protect the routes


#### How should this be manually tested?

- Clone the repo 

- In your home directory  cd this branch `fft-CRUD-on-article-#6`

- Then run `npm install` to install all dependencies

- Run `npm run dev` to start the server

- Use postman send a `POST` request on `http://localhost:3000/articles`

> You should see a returned result with success message along with saved article data

- Use postman send a `GET` request on `http://localhost:3000/articles` to get all articles in DB

> You should see the list of all articles in the DB

- To test delete endpoint, send a `DELETE` request on `http://localhost:3000/articles/_id` to delete a article with specified `_id`

> If `_id` given doesn't exist you should see a failure message saying that `the given ID doesn't exist or is invalid`

#### Any background context you want to provide?

- To be connected to DB you need to check `env-sample` for the credentials settings

- To get list of all articles in DB  you need to have an **Admin** account and send a `GET` request to `http://localhost:3000/articles/admin`

- Any logged in user should only be able to see his/her articles when send a `GET` request

- You don't need to specify the author, the author will be appended automatically at the database level

#### What are the relevant Trello stories?

- [#6](https://trello.com/c/oV9v0bK3/6-crud-on-artilces)

#### Screenshots (if appropriate)
<img width="1440" alt="articles-screenshot" src="https://user-images.githubusercontent.com/54619678/96359147-73358100-110f-11eb-9475-a0ebcc893e66.png">


#### Questions:

- N/A
