### PR TITLE
#7 ft(users): Enable CRUD operation on users

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -3,6 +3,7 @@ import './models/db';
 import authRouter from './routes/auth';
 import messageRoute from './routes/message.route';
 import articleRoutes from './routes/articles.route';
+import usersRoute from './routes/users.route';
 
 const app = express();
 app.use(express.json())
@@ -11,6 +12,7 @@ app.use(express.json())
 app.use('/users', authRouter)
 app.use('/message', messageRoute)
 app.use('/articles', articleRoutes)
+app.use('/users/info', usersRoute)
 
 
 app.use('/', (req, res) => {

--- a/src/controllers/users/index.js
+++ b/src/controllers/users/index.js
@@ -1,0 +1,62 @@
+import mongoose from 'mongoose';
+import User from '../../models/user';
+import Article from '../../models/article';
+
+export default {
+    getUsers: async (req, res) => {
+        try {
+            const user = await User.find({}, {'password': 0}).sort({registeredAt: -1});
+
+            return res.status(200).json({user})
+        } catch (err) {
+            return res.status(500).json({error: err.message})
+        }
+    },
+
+    deleteUser: async (req, res) => {
+        try {
+            const { _id } = req.params;
+            if (!mongoose.Types.ObjectId.isValid(_id)) return res.status(400).json({error: 'Invalid ID!'});
+            
+            const userToDelete = await User.findByIdAndDelete(_id);
+            if (!userToDelete) return res.status(404).json({error: 'No user with the given ID!'});
+
+            // eslint-disable-next-line 
+            let deletedUser = [];
+            if (userToDelete) {
+                const { name, email } = userToDelete;
+                deletedUser.push({
+                    name, email, _id
+                })
+                const deleteUserArticles = await Article.deleteMany().where({'author.name': { $eq: name}})
+                
+                return res.status(200).json({message: 'User deleted successfully', deletedUser, deleteUserArticles})
+            }
+            
+        } catch (err) {
+            return res.status(500).json({error: err.message})
+        }
+    },
+
+    editUser: async (req, res) => {
+        try {
+            const { isActive, isAdmin } = req.body;
+            const { _id } = req.params;
+            if (!mongoose.Types.ObjectId.isValid(_id)) return res.status(400).json({error: 'Invalid ID!'});
+
+            const userToUpdate = await User.findById({_id}, {'password': 0});
+            if (!userToUpdate) return res.status(404).json({error: 'No user with the given ID'});
+            
+            userToUpdate.set({
+                isAdmin ,
+                isActive 
+            });
+
+            const updatedUser = await userToUpdate.save();
+            
+            return res.status(200).json({message: 'User updated successfully', updatedUser})
+        } catch (err) {
+            return res.status(500).json({error: err.message})
+        }
+    } 
+}

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -17,7 +17,11 @@ const userSchema = new mongoose.Schema({
         type: Boolean,
         default: false
     },
-    registedAt: {
+    isActive: {
+        type: Boolean,
+        default: true
+    },
+    registeredAt: {
         type: Date,
         default: new Date()
     }

--- a/src/routes/users.route.js
+++ b/src/routes/users.route.js
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import userController from '../controllers/users';
+import { auth, adminAuth } from '../middlewares/authorization';
+
+const usersRoute = new Router();
+
+usersRoute
+    .get('/', [auth, adminAuth], userController.getUsers)
+    .delete('/:_id', [auth, adminAuth], userController.deleteUser)
+    .put('/:_id', [auth, adminAuth], userController.editUser)
+
+
+export default usersRoute;


### PR DESCRIPTION
#### What does this PR do?

- Enable manage users

#### Description of Task to be completed? 

- Add two one properties in user schema

- Add delete endpoint

- Add get endpoint

- Add update endpoint

- Protect the routes


#### How should this be manually tested?

- Clone the repo 

- In your home directory  cd this branch `ft-manage-users-#7`

- Then run `npm install` to install all dependencies

- Run `npm run dev` to start the server

- Use postman send a `GET` request on `http://localhost:3000/users/info`

> You should see a returned result with success message and list of all users

- Use postman send a `DELETE` request on `http://localhost:3000/users/info/id` to delete a users of a given `id`

> You should see a returned message stating that user is removed and also his/her articles will be deleted at the same time

-  Use postman send a `PUT` request on `http://localhost:3000/users/info/id` to update **isAdmin** or **isActive** properties


#### Any background context you want to provide?

- To be connected to DB you need to check `env-sample` for the credentials settings

- To **read** or **delete** and **update** user you need to have an **Admin** account

#### What are the relevant Trello stories?

- [#6](https://trello.com/c/yv00ZUUn/7-manage-users)

#### Screenshots (if appropriate)

<img width="1440" alt="manage-users" src="https://user-images.githubusercontent.com/54619678/96538775-a3109000-1299-11eb-964a-782434ec11fb.png">


#### Questions:

- N/A
